### PR TITLE
Initialize custom CTF platform skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-HV CTF Platform
+# HV CTF Platform
+
+This repository contains the first steps toward a custom Capture The Flag (CTF) platform based on [CTFd](https://github.com/CTFd/CTFd). The goal is to implement a minimal Flask application and gradually extend it with challenge management, scoring, and event features.
+
+## Development
+
+1. Create a Python virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Run the development server:
+
+```bash
+python -m hv_ctf.app
+```
+
+This will start a basic Flask app that can be extended with additional routes and logic.
+
+## Roadmap
+
+- [ ] Integrate CTFd components or use CTFd as a dependency
+- [ ] Add user authentication and team management
+- [ ] Implement challenge creation and solving workflow
+- [ ] Build a scoreboard with dynamic scoring
+- [ ] Support plugins and custom challenge types

--- a/hv_ctf/__init__.py
+++ b/hv_ctf/__init__.py
@@ -1,0 +1,1 @@
+"""Base package for HV CTF platform."""

--- a/hv_ctf/app.py
+++ b/hv_ctf/app.py
@@ -1,0 +1,30 @@
+from flask import Flask
+
+
+def create_app():
+    """Create a minimal Flask application for the custom CTF platform."""
+    app = Flask(__name__)
+
+    @app.route('/')
+    def index():
+        return "HV CTF platform"
+
+    @app.route('/scoreboard')
+    def scoreboard():
+        # Placeholder scoreboard logic
+        return "Scoreboard coming soon"
+
+    # Register example plugins
+    try:
+        from hv_ctf.plugins.simple_scoreboard import bp as scoreboard_bp
+        app.register_blueprint(scoreboard_bp)
+    except Exception as exc:
+        # Plugin import failed
+        app.logger.debug("Plugin failed: %s", exc)
+
+    return app
+
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(debug=True)

--- a/hv_ctf/plugins/__init__.py
+++ b/hv_ctf/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Plugins for HV CTF platform."""

--- a/hv_ctf/plugins/simple_scoreboard.py
+++ b/hv_ctf/plugins/simple_scoreboard.py
@@ -1,0 +1,10 @@
+"""Example plugin for customizing the scoreboard."""
+
+from flask import Blueprint
+
+bp = Blueprint('simple_scoreboard', __name__)
+
+@bp.route('/scoreboard')
+def custom_scoreboard():
+    # Example scoreboard output
+    return "Custom scoreboard from plugin"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=2.0
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,9 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from hv_ctf.app import create_app
+
+def test_index():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b"HV CTF platform" in resp.data


### PR DESCRIPTION
## Summary
- scaffold hv_ctf python package
- implement minimal Flask app with plugin registration
- add example plugin for custom scoreboard
- document setup in README
- set up tests and requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f568b9024832199ae11c61b352f4c